### PR TITLE
feat: notifications Twitch via EventSub webhook

### DIFF
--- a/.env.exemple
+++ b/.env.exemple
@@ -1,0 +1,18 @@
+DISCORD_TOKEN=YOUR_BOT_TOKEN
+CLIENT_ID=CLIENT_ID
+GUILD_ID=YOUR_GUILD_ID
+OWNER_ID=OWNER_ID
+NASA_APOD_KEY=NASA-APOD_API_KEY
+
+# Section WOL
+WOL_API_URL=http://wol.domain.com/wake
+WOL_API_TOKEN=your_token_here
+
+# Section Twitch EventSub
+TWITCH_CLIENT_ID=          # App client ID Twitch
+TWITCH_CLIENT_SECRET=      # App client secret Twitch
+TWITCH_BROADCASTER_ID=     # ID du streamer à surveiller
+TWITCH_WEBHOOK_SECRET=     # Secret HMAC (chaîne aléatoire longue)
+TWITCH_WEBHOOK_URL=        # URL publique du bot (ex: https://bot.example.com)
+TWITCH_WEBHOOK_PORT=3000   # Port du serveur HTTP
+TWITCH_NOTIFY_CHANNEL_ID=  # ID du salon Discord pour les notifs

--- a/events/Twitch/twitchNotif.js
+++ b/events/Twitch/twitchNotif.js
@@ -1,6 +1,0 @@
-const { SlashCommandBuilder, ChatInputCommandInteraction, Events } = require('discord.js');
-const { ownerId, clientId } = require('../../config.json');
-
-module.exports = {
-    name: Events.cl
-};

--- a/events/ready.js
+++ b/events/ready.js
@@ -1,4 +1,6 @@
 const { Events, ActivityType } = require('discord.js');
+const { startWebhookServer } = require('../src/twitch/webhookServer');
+const { subscribeToStreamOnline } = require('../src/twitch/subscriptions');
 
 module.exports = {
 	name: Events.ClientReady,
@@ -7,5 +9,13 @@ module.exports = {
         console.log(`${client.user.tag} est en ligne !`);
         client.user.setActivity('les étoiles ✨', { type: ActivityType.Watching });
         client.user.setStatus('online');
+
+        // Démarrage du serveur webhook Twitch EventSub
+        startWebhookServer(client);
+
+        // Abonnement à l'événement stream.online (ne bloque pas le démarrage)
+        subscribeToStreamOnline(process.env.TWITCH_BROADCASTER_ID).catch(err => {
+            console.error('[Twitch] Erreur non gérée lors de l\'abonnement EventSub:', err);
+        });
 	},
 };

--- a/src/twitch/notifier.js
+++ b/src/twitch/notifier.js
@@ -1,0 +1,179 @@
+'use strict';
+
+const { EmbedBuilder } = require('discord.js');
+
+/**
+ * Obtient un App Access Token Twitch (réutilisé depuis subscriptions, mais indépendant ici).
+ * @returns {Promise<string>}
+ */
+async function getAppAccessToken() {
+    const clientId = process.env.TWITCH_CLIENT_ID;
+    const clientSecret = process.env.TWITCH_CLIENT_SECRET;
+
+    if (!clientId || !clientSecret) {
+        throw new Error('TWITCH_CLIENT_ID ou TWITCH_CLIENT_SECRET non définis.');
+    }
+
+    const url = new URL('https://id.twitch.tv/oauth2/token');
+    url.searchParams.set('client_id', clientId);
+    url.searchParams.set('client_secret', clientSecret);
+    url.searchParams.set('grant_type', 'client_credentials');
+
+    const res = await fetch(url.toString(), { method: 'POST' });
+
+    if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`Échec de l'obtention du token Twitch (${res.status}): ${text}`);
+    }
+
+    const data = await res.json();
+    return data.access_token;
+}
+
+/**
+ * Récupère les informations d'un stream Twitch en cours.
+ * @param {string} token - App Access Token
+ * @param {string} userId - ID de l'utilisateur Twitch
+ * @returns {Promise<Object|null>}
+ */
+async function fetchStreamInfo(token, userId) {
+    const clientId = process.env.TWITCH_CLIENT_ID;
+
+    const res = await fetch(`https://api.twitch.tv/helix/streams?user_id=${encodeURIComponent(userId)}`, {
+        headers: {
+            'Client-ID': clientId,
+            'Authorization': `Bearer ${token}`,
+        },
+    });
+
+    if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`Échec de la récupération du stream (${res.status}): ${text}`);
+    }
+
+    const data = await res.json();
+    return data.data?.[0] || null;
+}
+
+/**
+ * Récupère les informations d'un utilisateur Twitch.
+ * @param {string} token - App Access Token
+ * @param {string} userId - ID de l'utilisateur Twitch
+ * @returns {Promise<Object|null>}
+ */
+async function fetchUserInfo(token, userId) {
+    const clientId = process.env.TWITCH_CLIENT_ID;
+
+    const res = await fetch(`https://api.twitch.tv/helix/users?id=${encodeURIComponent(userId)}`, {
+        headers: {
+            'Client-ID': clientId,
+            'Authorization': `Bearer ${token}`,
+        },
+    });
+
+    if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`Échec de la récupération de l'utilisateur (${res.status}): ${text}`);
+    }
+
+    const data = await res.json();
+    return data.data?.[0] || null;
+}
+
+/**
+ * Envoie une notification Discord quand un streamer passe en live.
+ * @param {import('discord.js').Client} client - Le client Discord
+ * @param {Object} event - Les données de l'événement EventSub stream.online
+ * @param {string} event.broadcaster_user_id - ID du broadcaster
+ * @param {string} event.broadcaster_user_name - Nom du broadcaster
+ * @param {string} event.broadcaster_user_login - Login du broadcaster
+ * @returns {Promise<void>}
+ */
+async function sendLiveNotification(client, event) {
+    const channelId = process.env.TWITCH_NOTIFY_CHANNEL_ID;
+
+    if (!channelId) {
+        console.error('[Twitch] TWITCH_NOTIFY_CHANNEL_ID non défini. Notification ignorée.');
+        return;
+    }
+
+    const channel = client.channels.cache.get(channelId);
+    if (!channel) {
+        console.error(`[Twitch] Salon Discord introuvable avec l'ID: ${channelId}`);
+        return;
+    }
+
+    const userId = event.broadcaster_user_id;
+    const userName = event.broadcaster_user_name || event.broadcaster_user_login || 'Streamer inconnu';
+    const userLogin = event.broadcaster_user_login || '';
+
+    let token;
+    try {
+        token = await getAppAccessToken();
+    } catch (err) {
+        console.error('[Twitch] Impossible d\'obtenir un token pour la notification:', err);
+        return;
+    }
+
+    // Récupération des infos stream et utilisateur en parallèle
+    let streamInfo = null;
+    let userInfo = null;
+
+    try {
+        [streamInfo, userInfo] = await Promise.all([
+            fetchStreamInfo(token, userId),
+            fetchUserInfo(token, userId),
+        ]);
+    } catch (err) {
+        console.error('[Twitch] Erreur lors de la récupération des infos Twitch:', err);
+        // On continue avec les infos disponibles
+    }
+
+    const streamTitle = streamInfo?.title || 'Pas de titre';
+    const gameName = streamInfo?.game_name || 'Jeu inconnu';
+    const viewerCount = streamInfo?.viewer_count ?? null;
+    const profileImage = userInfo?.profile_image_url || null;
+
+    // Thumbnail de la vignette du stream (1280x720), avec cache-busting
+    const thumbnailUrl = streamInfo?.thumbnail_url
+        ? streamInfo.thumbnail_url
+            .replace('{width}', '1280')
+            .replace('{height}', '720') + `?t=${Date.now()}`
+        : null;
+
+    const twitchUrl = `https://www.twitch.tv/${userLogin}`;
+
+    const embed = new EmbedBuilder()
+        .setColor(0x9146FF) // Violet Twitch
+        .setTitle(`🔴 ${userName} est en live !`)
+        .setURL(twitchUrl)
+        .setDescription(`**${streamTitle}**`)
+        .addFields(
+            { name: 'Jeu', value: gameName, inline: true },
+            ...(viewerCount !== null
+                ? [{ name: 'Spectateurs', value: viewerCount.toString(), inline: true }]
+                : []),
+        )
+        .setFooter({ text: 'Twitch' })
+        .setTimestamp();
+
+    if (thumbnailUrl) {
+        embed.setImage(thumbnailUrl);
+    }
+
+    if (profileImage) {
+        embed.setThumbnail(profileImage);
+    }
+
+    try {
+        await channel.send({
+            content: `**${userName}** est maintenant en live sur Twitch ! 🎮`,
+            embeds: [embed],
+        });
+        console.log(`[Twitch] Notification envoyée dans le salon ${channelId} pour ${userName}`);
+    } catch (err) {
+        console.error('[Twitch] Erreur lors de l\'envoi du message Discord:', err);
+    }
+}
+
+module.exports = { sendLiveNotification };

--- a/src/twitch/subscriptions.js
+++ b/src/twitch/subscriptions.js
@@ -1,0 +1,140 @@
+'use strict';
+
+/**
+ * Obtient un App Access Token Twitch via client_credentials.
+ * @returns {Promise<string>} Le token d'accès
+ */
+async function getAppAccessToken() {
+    const clientId = process.env.TWITCH_CLIENT_ID;
+    const clientSecret = process.env.TWITCH_CLIENT_SECRET;
+
+    if (!clientId || !clientSecret) {
+        throw new Error('TWITCH_CLIENT_ID ou TWITCH_CLIENT_SECRET non définis.');
+    }
+
+    const url = new URL('https://id.twitch.tv/oauth2/token');
+    url.searchParams.set('client_id', clientId);
+    url.searchParams.set('client_secret', clientSecret);
+    url.searchParams.set('grant_type', 'client_credentials');
+
+    const res = await fetch(url.toString(), { method: 'POST' });
+
+    if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`Échec de l'obtention du token Twitch (${res.status}): ${text}`);
+    }
+
+    const data = await res.json();
+    return data.access_token;
+}
+
+/**
+ * Vérifie si un abonnement stream.online existe déjà pour le broadcaster donné.
+ * @param {string} token - App Access Token
+ * @param {string} broadcasterId - ID du broadcaster
+ * @returns {Promise<boolean>}
+ */
+async function subscriptionExists(token, broadcasterId) {
+    const clientId = process.env.TWITCH_CLIENT_ID;
+    const callbackUrl = (process.env.TWITCH_WEBHOOK_URL || '') + '/webhook/twitch';
+
+    const res = await fetch('https://api.twitch.tv/helix/eventsub/subscriptions', {
+        headers: {
+            'Client-ID': clientId,
+            'Authorization': `Bearer ${token}`,
+        },
+    });
+
+    if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`Échec de la vérification des abonnements (${res.status}): ${text}`);
+    }
+
+    const data = await res.json();
+    const existing = (data.data || []).find(sub =>
+        sub.type === 'stream.online' &&
+        sub.condition?.broadcaster_user_id === broadcasterId &&
+        sub.transport?.callback === callbackUrl &&
+        (sub.status === 'enabled' || sub.status === 'webhook_callback_verification_pending')
+    );
+
+    return Boolean(existing);
+}
+
+/**
+ * Crée un abonnement EventSub stream.online pour le broadcaster donné.
+ * @param {string} token - App Access Token
+ * @param {string} broadcasterId - ID du broadcaster
+ * @returns {Promise<void>}
+ */
+async function createSubscription(token, broadcasterId) {
+    const clientId = process.env.TWITCH_CLIENT_ID;
+    const webhookUrl = process.env.TWITCH_WEBHOOK_URL;
+    const secret = process.env.TWITCH_WEBHOOK_SECRET;
+
+    if (!webhookUrl) {
+        throw new Error('TWITCH_WEBHOOK_URL non défini.');
+    }
+    if (!secret) {
+        throw new Error('TWITCH_WEBHOOK_SECRET non défini.');
+    }
+
+    const body = {
+        type: 'stream.online',
+        version: '1',
+        condition: {
+            broadcaster_user_id: broadcasterId,
+        },
+        transport: {
+            method: 'webhook',
+            callback: webhookUrl + '/webhook/twitch',
+            secret: secret,
+        },
+    };
+
+    const res = await fetch('https://api.twitch.tv/helix/eventsub/subscriptions', {
+        method: 'POST',
+        headers: {
+            'Client-ID': clientId,
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`Échec de la création de l'abonnement (${res.status}): ${text}`);
+    }
+
+    console.log(`[Twitch] Abonnement stream.online créé pour broadcaster_id: ${broadcasterId}`);
+}
+
+/**
+ * S'abonne à l'événement stream.online pour un broadcaster.
+ * Vérifie d'abord si l'abonnement existe déjà avant de le créer.
+ * @param {string} broadcasterId - ID du broadcaster Twitch
+ * @returns {Promise<void>}
+ */
+async function subscribeToStreamOnline(broadcasterId) {
+    if (!broadcasterId) {
+        console.error('[Twitch] TWITCH_BROADCASTER_ID non défini. Abonnement ignoré.');
+        return;
+    }
+
+    try {
+        const token = await getAppAccessToken();
+
+        const alreadyExists = await subscriptionExists(token, broadcasterId);
+        if (alreadyExists) {
+            console.log(`[Twitch] Abonnement stream.online déjà actif pour broadcaster_id: ${broadcasterId}`);
+            return;
+        }
+
+        await createSubscription(token, broadcasterId);
+    } catch (err) {
+        console.error('[Twitch] Erreur lors de l\'abonnement EventSub:', err);
+    }
+}
+
+module.exports = { subscribeToStreamOnline };

--- a/src/twitch/webhookServer.js
+++ b/src/twitch/webhookServer.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const http = require('node:http');
+const crypto = require('node:crypto');
+const { sendLiveNotification } = require('./notifier');
+
+const TWITCH_MESSAGE_ID = 'twitch-eventsub-message-id';
+const TWITCH_MESSAGE_TIMESTAMP = 'twitch-eventsub-message-timestamp';
+const TWITCH_MESSAGE_SIGNATURE = 'twitch-eventsub-message-signature';
+const TWITCH_MESSAGE_TYPE = 'twitch-eventsub-message-type';
+
+const MESSAGE_TYPE_VERIFICATION = 'webhook_callback_verification';
+const MESSAGE_TYPE_NOTIFICATION = 'notification';
+const MESSAGE_TYPE_REVOCATION = 'revocation';
+
+/**
+ * Vérifie la signature HMAC-SHA256 de la requête Twitch.
+ * @param {string} secret - Le secret HMAC configuré
+ * @param {http.IncomingMessage} req - La requête HTTP
+ * @param {string} body - Le corps brut de la requête (string)
+ * @returns {boolean}
+ */
+function verifySignature(secret, req, body) {
+    const messageId = req.headers[TWITCH_MESSAGE_ID];
+    const timestamp = req.headers[TWITCH_MESSAGE_TIMESTAMP];
+    const signature = req.headers[TWITCH_MESSAGE_SIGNATURE];
+
+    if (!messageId || !timestamp || !signature) return false;
+
+    const hmacMessage = messageId + timestamp + body;
+    const hmac = 'sha256=' + crypto
+        .createHmac('sha256', secret)
+        .update(hmacMessage)
+        .digest('hex');
+
+    // Comparaison en temps constant pour éviter les timing attacks
+    try {
+        return crypto.timingSafeEqual(Buffer.from(hmac), Buffer.from(signature));
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Lit le corps complet d'une requête HTTP.
+ * @param {http.IncomingMessage} req
+ * @returns {Promise<string>}
+ */
+function readBody(req) {
+    return new Promise((resolve, reject) => {
+        let data = '';
+        req.on('data', chunk => { data += chunk; });
+        req.on('end', () => resolve(data));
+        req.on('error', reject);
+    });
+}
+
+/**
+ * Démarre le serveur HTTP pour recevoir les webhooks Twitch EventSub.
+ * @param {import('discord.js').Client} client - Le client Discord
+ */
+function startWebhookServer(client) {
+    const port = process.env.TWITCH_WEBHOOK_PORT || 3000;
+    const secret = process.env.TWITCH_WEBHOOK_SECRET;
+
+    if (!secret) {
+        console.error('[Twitch] TWITCH_WEBHOOK_SECRET non défini. Le serveur webhook ne démarrera pas.');
+        return;
+    }
+
+    const server = http.createServer(async (req, res) => {
+        // On ne traite que POST /webhook/twitch
+        if (req.method !== 'POST' || req.url !== '/webhook/twitch') {
+            res.writeHead(404);
+            res.end();
+            return;
+        }
+
+        let body;
+        try {
+            body = await readBody(req);
+        } catch (err) {
+            console.error('[Twitch] Erreur lecture du corps de la requête:', err);
+            res.writeHead(400);
+            res.end();
+            return;
+        }
+
+        // Vérification de la signature
+        if (!verifySignature(secret, req, body)) {
+            console.warn('[Twitch] Signature invalide reçue, requête rejetée.');
+            res.writeHead(403);
+            res.end();
+            return;
+        }
+
+        let payload;
+        try {
+            payload = JSON.parse(body);
+        } catch (err) {
+            console.error('[Twitch] Corps JSON invalide:', err);
+            res.writeHead(400);
+            res.end();
+            return;
+        }
+
+        const messageType = req.headers[TWITCH_MESSAGE_TYPE];
+
+        // Challenge de vérification d'abonnement
+        if (messageType === MESSAGE_TYPE_VERIFICATION) {
+            const challenge = payload.challenge;
+            console.log('[Twitch] Challenge de vérification reçu, réponse envoyée.');
+            res.writeHead(200, { 'Content-Type': 'text/plain' });
+            res.end(challenge);
+            return;
+        }
+
+        // Révocation d'abonnement
+        if (messageType === MESSAGE_TYPE_REVOCATION) {
+            console.warn(`[Twitch] Abonnement révoqué: ${payload.subscription?.type} — raison: ${payload.subscription?.status}`);
+            res.writeHead(204);
+            res.end();
+            return;
+        }
+
+        // Notification d'événement
+        if (messageType === MESSAGE_TYPE_NOTIFICATION) {
+            const subscriptionType = payload.subscription?.type;
+
+            res.writeHead(204);
+            res.end();
+
+            if (subscriptionType === 'stream.online') {
+                console.log(`[Twitch] Événement stream.online reçu pour broadcaster_id: ${payload.event?.broadcaster_user_id}`);
+                try {
+                    await sendLiveNotification(client, payload.event);
+                } catch (err) {
+                    console.error('[Twitch] Erreur lors de l\'envoi de la notification Discord:', err);
+                }
+            }
+
+            return;
+        }
+
+        // Type inconnu
+        res.writeHead(204);
+        res.end();
+    });
+
+    server.on('error', err => {
+        console.error('[Twitch] Erreur du serveur webhook:', err);
+    });
+
+    server.listen(port, () => {
+        console.log(`[Twitch] Serveur webhook démarré sur le port ${port}`);
+    });
+}
+
+module.exports = { startWebhookServer };


### PR DESCRIPTION
## Résumé
- Serveur HTTP natif (`node:http`) sur `TWITCH_WEBHOOK_PORT` (défaut: 3000)
- Vérification signature HMAC-SHA256 avec comparaison en temps constant (`timingSafeEqual`)
- Gestion du challenge de vérification Twitch, des notifications `stream.online` et des révocations
- Abonnement EventSub au démarrage avec vérification doublon (évite les abonnements multiples)
- Embed Discord avec titre, jeu, thumbnail, compteur spectateurs et avatar streamer
- Zéro dépendance externe — `node:http`, `node:crypto`, `fetch` natif Node 18+
- Suppression de `events/Twitch/twitchNotif.js` (stub incomplet)

## Nouvelles variables d'environnement (`.env`)
```
TWITCH_CLIENT_ID=
TWITCH_CLIENT_SECRET=
TWITCH_BROADCASTER_ID=
TWITCH_WEBHOOK_SECRET=
TWITCH_WEBHOOK_URL=        # URL publique accessible par Twitch (ex: https://bot.example.com)
TWITCH_WEBHOOK_PORT=3000
TWITCH_NOTIFY_CHANNEL_ID=
```

## Plan de test
- [ ] Serveur webhook démarre sur le bon port
- [ ] Challenge Twitch répond correctement (abonnement validé)
- [ ] Requête avec signature invalide retourne 403
- [ ] Notification `stream.online` envoie l'embed dans le bon salon
- [ ] Pas d'abonnement dupliqué si déjà actif
- [ ] Bot ne crashe pas si `TWITCH_*` vars manquantes

## Note
Requiert une URL publique pour que Twitch puisse atteindre le webhook (ngrok en dev, reverse proxy en prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)