### PR TITLE
ci: auto-deploy Discord slash commands on push to main

### DIFF
--- a/.github/workflows/deploy-commands.yml
+++ b/.github/workflows/deploy-commands.yml
@@ -1,0 +1,31 @@
+name: Deploy Discord Commands
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'commands/**'
+      - 'deploy-commands.js'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --omit=dev --ignore-scripts
+
+      - name: Deploy slash commands
+        env:
+          DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          GUILD_ID: ${{ secrets.GUILD_ID }}
+        run: npm run deploy


### PR DESCRIPTION
## Résumé
- Nouveau workflow GitHub Actions qui déploie automatiquement les slash commands Discord à chaque push sur `main`
- Se déclenche uniquement si `commands/**` ou `deploy-commands.js` sont modifiés (pas de deploy inutile)
- Requiert les secrets GitHub : `DISCORD_TOKEN`, `CLIENT_ID`, `GUILD_ID`

🤖 Generated with [Claude Code](https://claude.com/claude-code)