### PR TITLE
ci: moderniser le workflow Docker Build & Push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,28 +1,44 @@
-name: Docker Build and Push
+name: Build & Push
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [main]
 
 jobs:
-  build-and-push:
+  build:
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+    permissions:
+      contents: read
+      packages: write
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Light Image
-        uses: docker/build-push-action@v6
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/axtazer/axtazia
+          tags: |
+            type=sha,prefix=,format=short
+            type=raw,value=latest
+
+      - name: Setup BuildKit
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build & Push
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
-          tags: ghcr.io/axtazer/axtazia:latest
-          labels: |
-            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Changements
- Tags SHA (`type=sha`) + `latest` via `docker/metadata-action@v6` — l'image est maintenant identifiable par commit
- BuildKit activé (`setup-buildx-action@v4`) + cache GitHub Actions pour des builds plus rapides
- Permissions explicites `contents: read` / `packages: write`
- Versions des actions alignées sur le format du projet : `checkout@v6`, `login-action@v4`, `build-push-action@v7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)