### PR TITLE
fix: copy src/ directory in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
 COPY --from=builder /app/index.js ./
 COPY --from=builder /app/commands ./commands
 COPY --from=builder /app/events ./events
+COPY --from=builder /app/src ./src
 
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \


### PR DESCRIPTION
## Summary
- Adds `COPY --from=builder /app/src ./src` to the Dockerfile runner stage
- Fixes `MODULE_NOT_FOUND` crash at startup caused by missing `src/twitch/webhookServer.js` in the image

## Test plan
- [ ] CI builds and pushes new image successfully
- [ ] Pod starts without `MODULE_NOT_FOUND` error
- [ ] Twitch webhook server starts on port 3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)