### PR TITLE
feat: uptime serveur dans le widget de profil Discord

### DIFF
--- a/events/ready.js
+++ b/events/ready.js
@@ -1,6 +1,7 @@
 const { Events, ActivityType } = require('discord.js');
 const { startWebhookServer } = require('../src/twitch/webhookServer');
 const { subscribeToStreamOnline } = require('../src/twitch/subscriptions');
+const { startProfileWidgetUpdates } = require('../src/discord/profileWidget');
 
 module.exports = {
 	name: Events.ClientReady,
@@ -17,5 +18,8 @@ module.exports = {
         subscribeToStreamOnline(process.env.TWITCH_BROADCASTER_ID).catch(err => {
             console.error('[Twitch] Erreur non gérée lors de l\'abonnement EventSub:', err);
         });
+
+        // Widget de profil (uptime serveur via Prometheus)
+        startProfileWidgetUpdates();
 	},
 };

--- a/src/discord/profileWidget.js
+++ b/src/discord/profileWidget.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const PROMETHEUS_URL = process.env.PROMETHEUS_URL || 'http://vmsingle-victoria-metrics-k8s-stack.monitoring.svc.cluster.local:8428';
+
+/**
+ * Formate une durée en secondes en chaîne courte (ex: 93132 -> "1d 2h 12m").
+ * @param {number} totalSeconds
+ * @returns {string}
+ */
+function formatUptime(totalSeconds) {
+    const seconds = Math.max(0, Math.floor(totalSeconds));
+    const days = Math.floor(seconds / 86400);
+    const hours = Math.floor((seconds % 86400) / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+
+    const parts = [];
+    if (days) parts.push(`${days}d`);
+    if (days || hours) parts.push(`${hours}h`);
+    parts.push(`${minutes}m`);
+
+    return parts.join(' ');
+}
+
+/**
+ * Récupère l'uptime du node (en secondes) via Prometheus (node_boot_time_seconds).
+ * @returns {Promise<number>}
+ */
+async function fetchServerUptimeSeconds() {
+    const url = new URL('/api/v1/query', PROMETHEUS_URL);
+    url.searchParams.set('query', 'node_boot_time_seconds');
+
+    const res = await fetch(url.toString());
+
+    if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`Échec de la requête Prometheus (${res.status}): ${text}`);
+    }
+
+    const data = await res.json();
+    const result = data.data?.result?.[0];
+
+    if (!result) {
+        throw new Error('Aucune métrique node_boot_time_seconds retournée par Prometheus.');
+    }
+
+    const bootTime = Number(result.value[1]);
+    return Date.now() / 1000 - bootTime;
+}
+
+/**
+ * Met à jour le widget de profil de l'application (identity profile) avec l'uptime formaté.
+ * @param {string} formattedUptime
+ * @returns {Promise<void>}
+ */
+async function updateProfileWidget(formattedUptime) {
+    const applicationId = process.env.CLIENT_ID;
+    const userId = process.env.CLIENT_ID;
+    const token = process.env.DISCORD_TOKEN;
+
+    const url = `https://discord.com/api/v9/applications/${applicationId}/users/${userId}/identities/0/profile`;
+
+    const body = {
+        data: {
+            dynamic: [
+                { type: 1, name: 'uptime', value: formattedUptime },
+            ],
+        },
+    };
+
+    const res = await fetch(url, {
+        method: 'PATCH',
+        headers: {
+            'Authorization': `Bot ${token}`,
+            'Content-Type': 'application/json',
+            'User-Agent': 'DiscordBot (https://github.com/Axtazer/Axtazia, 1.0.0)',
+        },
+        body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`Échec de la mise à jour du widget de profil (${res.status}): ${text}`);
+    }
+}
+
+const TEN_MINUTES = 10 * 60 * 1000;
+const THIRTY_MINUTES = 30 * 60 * 1000;
+const ONE_DAY_SECONDS = 24 * 60 * 60;
+
+let refreshTimeout = null;
+
+/**
+ * Rafraîchit le widget de profil et reprogramme le prochain rafraîchissement.
+ * Fréquence adaptative : 10 min si uptime < 24h, sinon 30 min.
+ */
+async function refreshAndReschedule() {
+    let nextDelay = TEN_MINUTES;
+
+    try {
+        const uptimeSeconds = await fetchServerUptimeSeconds();
+        await updateProfileWidget(formatUptime(uptimeSeconds));
+        nextDelay = uptimeSeconds < ONE_DAY_SECONDS ? TEN_MINUTES : THIRTY_MINUTES;
+    } catch (err) {
+        console.error('[ProfileWidget] Erreur lors du rafraîchissement de l\'uptime:', err);
+    }
+
+    refreshTimeout = setTimeout(refreshAndReschedule, nextDelay);
+}
+
+/**
+ * Démarre le cycle de mise à jour périodique du widget de profil.
+ */
+function startProfileWidgetUpdates() {
+    if (refreshTimeout) return;
+    refreshAndReschedule();
+}
+
+module.exports = { formatUptime, fetchServerUptimeSeconds, updateProfileWidget, startProfileWidgetUpdates };


### PR DESCRIPTION
## Summary
- Récupère l'uptime du node hôte (`node_boot_time_seconds` via VictoriaMetrics) et le formate en chaîne courte (`1d 2h 12m`)
- Met à jour périodiquement le champ `uptime` (type string) du widget de profil de l'application via l'endpoint non-officiel `PATCH /applications/{id}/users/{id}/identities/0/profile`
- Fréquence adaptative : 10 min si uptime < 24h, 30 min sinon
- Démarré depuis `events/ready.js` au boot du bot

## Config requise
- `CLIENT_ID` et `DISCORD_TOKEN` déjà présents dans le secret `axtazia-secrets`
- `PROMETHEUS_URL` optionnel (défaut pointe déjà vers `vmsingle-victoria-metrics-k8s-stack.monitoring.svc.cluster.local:8428`)

## Notes
- Endpoint Discord non documenté officiellement (`/api/v9/.../identities/0/profile`), susceptible de changer sans préavis
- En cas d'échec (Prometheus injoignable, etc.), le champ n'est jamais écrasé avec une valeur vide — la dernière valeur connue reste affichée, seul un nouveau retry est planifié

## Test plan
- [ ] Déployer sur le cluster et vérifier les logs au démarrage (`[ProfileWidget]` en cas d'erreur)
- [ ] Vérifier sur le profil Discord de l'app que le champ `uptime` se met à jour après le premier cycle
- [ ] Couper temporairement l'accès à Prometheus pour valider que la dernière valeur reste affichée sans crash du bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)