### PR TITLE
fix: state OAuth2 signé au lieu d'un Map en mémoire

### DIFF
--- a/src/discord/oauth.js
+++ b/src/discord/oauth.js
@@ -7,19 +7,28 @@ const AUTHORIZE_URL = 'https://discord.com/oauth2/authorize';
 const SCOPE = 'application_identities.write';
 const STATE_TTL_MS = 10 * 60 * 1000;
 
-const pendingStates = new Map();
+/**
+ * Signe un state pour le protéger contre la falsification (CSRF), sans stockage
+ * côté serveur : la validité tient à la signature HMAC + un TTL sur le timestamp.
+ * Reste valide à travers un redémarrage du process (contrairement à un Map en mémoire).
+ * @param {number} timestamp
+ * @returns {string}
+ */
+function signState(timestamp) {
+    const secret = process.env.DISCORD_CLIENT_SECRET;
+    const hmac = crypto.createHmac('sha256', secret).update(String(timestamp)).digest('base64url');
+    return `${timestamp}.${hmac}`;
+}
 
 /**
  * Construit l'URL d'autorisation OAuth2 à visiter manuellement (une seule fois).
- * Génère un paramètre state à usage unique pour se protéger du CSRF.
+ * Inclut un state signé pour se protéger du CSRF.
  * @returns {string}
  */
 function buildAuthorizeUrl() {
     const clientId = process.env.CLIENT_ID;
     const redirectUri = process.env.DISCORD_OAUTH_REDIRECT_URI;
-
-    const state = crypto.randomBytes(32).toString('base64url');
-    pendingStates.set(state, Date.now() + STATE_TTL_MS);
+    const state = signState(Date.now());
 
     const url = new URL(AUTHORIZE_URL);
     url.searchParams.set('client_id', clientId);
@@ -32,16 +41,25 @@ function buildAuthorizeUrl() {
 }
 
 /**
- * Vérifie et consomme un state reçu sur le callback OAuth2 (usage unique, protection CSRF).
+ * Vérifie un state reçu sur le callback OAuth2 (signature + fraîcheur, protection CSRF).
  * @param {string} state
  * @returns {boolean}
  */
 function consumeState(state) {
-    const expiresAt = pendingStates.get(state);
-    if (!expiresAt) return false;
+    const [timestampRaw, hmac] = String(state).split('.');
+    if (!timestampRaw || !hmac) return false;
 
-    pendingStates.delete(state);
-    return Date.now() <= expiresAt;
+    const timestamp = Number(timestampRaw);
+    if (!Number.isFinite(timestamp) || Date.now() - timestamp > STATE_TTL_MS || timestamp > Date.now()) {
+        return false;
+    }
+
+    const expected = signState(timestamp).split('.')[1];
+    const a = Buffer.from(hmac);
+    const b = Buffer.from(expected);
+    if (a.length !== b.length) return false;
+
+    return crypto.timingSafeEqual(a, b);
 }
 
 /**

--- a/src/twitch/webhookServer.js
+++ b/src/twitch/webhookServer.js
@@ -77,7 +77,7 @@ function startWebhookServer(client) {
             const state = params.get('state');
 
             if (!code || !state || !consumeState(state)) {
-                res.writeHead(400, { 'Content-Type': 'text/plain' });
+                res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
                 res.end('Requête invalide ou expirée (code/state manquant ou incorrect). Relance buildAuthorizeUrl().');
                 return;
             }
@@ -85,11 +85,11 @@ function startWebhookServer(client) {
             try {
                 const tokens = await exchangeCodeForToken(code);
                 console.log('[OAuth] Autorisation réussie, refresh_token obtenu.');
-                res.writeHead(200, { 'Content-Type': 'text/plain' });
+                res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
                 res.end(`Autorisation réussie. Copie ce refresh_token dans 1Password (DISCORD_OAUTH_REFRESH_TOKEN) puis ferme cette page :\n\n${tokens.refresh_token}`);
             } catch (err) {
                 console.error('[OAuth] Échec de l\'échange du code:', err);
-                res.writeHead(500, { 'Content-Type': 'text/plain' });
+                res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
                 res.end('Échec de l\'autorisation, voir les logs du bot.');
             }
             return;
@@ -136,7 +136,7 @@ function startWebhookServer(client) {
         if (messageType === MESSAGE_TYPE_VERIFICATION) {
             const challenge = payload.challenge;
             console.log('[Twitch] Challenge de vérification reçu, réponse envoyée.');
-            res.writeHead(200, { 'Content-Type': 'text/plain' });
+            res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
             res.end(challenge);
             return;
         }


### PR DESCRIPTION
## Summary
- Le `state` CSRF (#16) était stocké dans un `Map` en mémoire (`pendingStates`) — ne survit pas à un redémarrage du process. Une URL copiée depuis un ancien boot (logs remontés) devenait invalide même sans redeploy entre temps
- Remplacé par un state auto-vérifiable : `timestamp.HMAC(timestamp, DISCORD_CLIENT_SECRET)`, validé par recalcul de la signature + TTL 10 min, sans dépendance à l'état du process
- Bonus : `charset=utf-8` sur les réponses `text/plain` du callback OAuth2 (texte français mal encodé sinon)

## Test plan
- [ ] Déployer, récupérer l'URL dans les logs, autoriser normalement → doit marcher
- [ ] Vérifier que le texte de la page de callback s'affiche correctement (accents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)