### PR TITLE
debug: logger le flag Social SDK de l'application

### DIFF
--- a/src/discord/profileWidget.js
+++ b/src/discord/profileWidget.js
@@ -71,6 +71,11 @@ async function getApplicationOwnerId() {
     const data = await res.json();
     cachedOwnerId = data.owner?.id;
 
+    // Debug temporaire : vérifie le bit Social SDK (1 << 10 = 1024) dans flags.
+    const flags = data.flags ?? 0;
+    const socialSdkEnabled = (flags & (1 << 10)) !== 0;
+    console.log(`[ProfileWidget] Debug application: id=${data.id} owner=${cachedOwnerId} flags=${flags} socialSdkEnabled=${socialSdkEnabled}`);
+
     if (!cachedOwnerId) {
         throw new Error('owner_id introuvable dans la réponse oauth2/applications/@me.');
     }


### PR DESCRIPTION
## Summary
- Le PATCH `identities/0/profile` renvoie toujours `403 50025` même avec `Bot {token}` (revert #19) une fois déployé, alors que la GET `oauth2/applications/@me` réussit
- Ajoute un log temporaire au premier cycle pour afficher `flags` brut et vérifier si le bit Social SDK (`1 << 10`) est réellement actif côté Discord

## Test plan
- [ ] Déployer, checker les logs pour la ligne `[ProfileWidget] Debug application: ...`
- [ ] Confirmer ou infirmer `socialSdkEnabled`
- [ ] Retirer ce log une fois le diagnostic terminé

🤖 Generated with [Claude Code](https://claude.com/claude-code)