### PR TITLE
fix: cibler OWNER_ID directement au lieu de owner.id (Team ID)

### DIFF
--- a/src/discord/profileWidget.js
+++ b/src/discord/profileWidget.js
@@ -47,40 +47,21 @@ async function fetchServerUptimeSeconds() {
     return Date.now() / 1000 - bootTime;
 }
 
-let cachedOwnerId = null;
-
 /**
- * Récupère (et met en cache) l'owner_id de l'application, via l'API Discord.
- * C'est le compte propriétaire de l'app qui possède l'identity profile ciblée
- * par le widget (pas le bot lui-même).
- * @returns {Promise<string>}
+ * ID du compte personnel ciblé par le widget (pas le bot lui-même).
+ * Note : oauth2/applications/@me renvoie owner.id = l'ID de la Team si
+ * l'app est possédée par une Team, pas un vrai compte utilisateur — donc
+ * on utilise directement OWNER_ID plutôt que de faire confiance à ce champ.
+ * @returns {string}
  */
-async function getApplicationOwnerId() {
-    if (cachedOwnerId) return cachedOwnerId;
+function getApplicationOwnerId() {
+    const ownerId = process.env.OWNER_ID;
 
-    const token = process.env.DISCORD_TOKEN;
-    const res = await fetch('https://discord.com/api/v10/oauth2/applications/@me', {
-        headers: { 'Authorization': `Bot ${token}` },
-    });
-
-    if (!res.ok) {
-        const text = await res.text();
-        throw new Error(`Échec de la récupération des infos application (${res.status}): ${text}`);
+    if (!ownerId) {
+        throw new Error('OWNER_ID non défini.');
     }
 
-    const data = await res.json();
-    cachedOwnerId = data.owner?.id;
-
-    // Debug temporaire : vérifie le bit Social SDK (1 << 10 = 1024) dans flags.
-    const flags = data.flags ?? 0;
-    const socialSdkEnabled = (flags & (1 << 10)) !== 0;
-    console.log(`[ProfileWidget] Debug application: id=${data.id} owner=${cachedOwnerId} flags=${flags} socialSdkEnabled=${socialSdkEnabled}`);
-
-    if (!cachedOwnerId) {
-        throw new Error('owner_id introuvable dans la réponse oauth2/applications/@me.');
-    }
-
-    return cachedOwnerId;
+    return ownerId;
 }
 
 /**
@@ -91,7 +72,7 @@ async function getApplicationOwnerId() {
 async function updateProfileWidget(formattedUptime) {
     const applicationId = process.env.CLIENT_ID;
     const token = process.env.DISCORD_TOKEN;
-    const userId = await getApplicationOwnerId();
+    const userId = getApplicationOwnerId();
 
     const url = `https://discord.com/api/v9/applications/${applicationId}/users/${userId}/identities/0/profile`;
 


### PR DESCRIPTION
## Summary
- Le debug (#20) a confirmé `socialSdkEnabled=true`, donc le flag n'était pas le problème
- `owner.id` retourné par `oauth2/applications/@me` (`739912335698952253`) ne correspond ni au bot ni au compte perso d'Axtazer — l'app est possédée par une **Team** Discord, et ce champ renvoie l'ID de la Team, pas un compte utilisateur valide pour `identities/0/profile`
- Utilise directement `OWNER_ID` (le vrai compte personnel, déjà en env) au lieu de faire confiance à `owner.id`
- Retire au passage le debug logging de #20 (plus nécessaire), et simplifie en fonction synchrone (plus de GET requis)

## Test plan
- [ ] Déployer et vérifier l'absence d'erreur `[ProfileWidget]`
- [ ] Vérifier sur le profil Discord perso d'Axtazer que le champ `uptime` apparaît

🤖 Generated with [Claude Code](https://claude.com/claude-code)